### PR TITLE
Fix for GetKanjiDefinitionAsync sometimes fail

### DIFF
--- a/JishoNET.Kanji/JishoNET.cs
+++ b/JishoNET.Kanji/JishoNET.cs
@@ -7,80 +7,84 @@ using JishoNET.Models;
 
 namespace JishoNET
 {
-    public static class JishoNETKanji
-    {
-        public static async Task<JishoResult<JishoKanjiDefinition>> GetKanjiDefinitionAsync(this JishoClient client, string keyword)
-        {
-            string kanjiUrlBase = "https://jisho.org/search/";
-            string request = $"{kanjiUrlBase}{keyword} %23kanji";
+	public static class JishoNETKanji
+	{
+		public static async Task<JishoResult<JishoKanjiDefinition>> GetKanjiDefinitionAsync(this JishoClient client,
+			string keyword)
+		{
+			const string kanjiUrlBase = "https://jisho.org/search/";
+			string request = $"{kanjiUrlBase}{keyword} %23kanji";
 
-            try
-            {
-                string htmlData = await new HttpClient().GetAsync(request).Result.Content.ReadAsStringAsync();
-                HtmlDocument htmlDocument = new HtmlDocument();
-                htmlDocument.LoadHtml(htmlData);
+			try
+			{
+				string htmlData = await new HttpClient().GetAsync(request).Result.Content.ReadAsStringAsync();
+				HtmlDocument htmlDocument = new HtmlDocument();
+				htmlDocument.LoadHtml(htmlData);
 
-                JishoKanjiDefinition result = new JishoKanjiDefinition();
+				JishoKanjiDefinition result = new JishoKanjiDefinition();
 
-                // Save the user input as the kanji
-                result.Kanji = keyword;
+				// Save the user input as the kanji
+				result.Kanji = keyword;
 
-                // Get the meaning of the kanji from the node with class kanji-details__main-meanings
-                HtmlNode meaningNode = htmlDocument.DocumentNode.SelectSingleNode("//div[@class='kanji-details__main-meanings']");
-                result.Meanings = meaningNode.InnerText.Split(',').Select(x => x.Trim()).ToArray();
+				// Get the meaning of the kanji from the node with class kanji-details__main-meanings
+				HtmlNode meaningNode =
+					htmlDocument.DocumentNode.SelectSingleNode("//div[@class='kanji-details__main-meanings']");
+				result.Meanings = meaningNode.InnerText.Split(',').Select(x => x.Trim()).ToArray();
 
-                // Get the Kunyomi and Onyomi readings from the node with class kanji-details__main-readings
-                HtmlNode readingsNode = htmlDocument.DocumentNode.SelectSingleNode("//div[@class='kanji-details__main-readings']");
+				// Get the Kunyomi and Onyomi readings from the node with class kanji-details__main-readings
+				HtmlNode readingsNode =
+					htmlDocument.DocumentNode.SelectSingleNode("//div[@class='kanji-details__main-readings']");
 
-                // In the readings node there are 2 nodes that need to be processed. 
-                HtmlNode KunyomiNode = readingsNode.SelectSingleNode("//*[@class='dictionary_entry kun_yomi']");
-                HtmlNode OnyomiNode = readingsNode.SelectNodes("//*[@class='dictionary_entry on_yomi']").Last();
+				// In the readings node there are 2 nodes that need to be processed. 
+				HtmlNode KunyomiNode = readingsNode.SelectSingleNode("//*[@class='dictionary_entry kun_yomi']");
+				HtmlNode OnyomiNode = readingsNode.SelectNodes("//*[@class='dictionary_entry on_yomi']").Last();
 
-                List<string> kunyomiReadings = new List<string>();
-                List<string> onyomiReadings = new List<string>();
+				List<string> kunyomiReadings = new List<string>();
+				List<string> onyomiReadings = new List<string>();
 
-                // For each node, extract all the anchor tags and save their inner text, trimmed to a list
-                if (KunyomiNode != null)
-                    foreach (HtmlNode node in KunyomiNode.Descendants().Where(x => x.Name == "a"))
-                        kunyomiReadings.Add(node.InnerText.Trim());
-                if (OnyomiNode != null)
-                    foreach (HtmlNode node in OnyomiNode.Descendants().Where(x => x.Name == "a"))
-                        onyomiReadings.Add(node.InnerText.Trim());
+				// For each node, extract all the anchor tags and save their inner text, trimmed to a list
+				if (KunyomiNode != null)
+					kunyomiReadings.AddRange(KunyomiNode.Descendants().Where(x => x.Name == "a")
+						.Select(node => node.InnerText.Trim()));
+				if (OnyomiNode != null)
+					onyomiReadings.AddRange(OnyomiNode.Descendants().Where(x => x.Name == "a")
+						.Select(node => node.InnerText.Trim()));
 
-                // Save the lists as arrays to the result
-                result.KunyomiReadings = kunyomiReadings.ToArray();
-                result.OnyomiReadings = onyomiReadings.ToArray();
+				// Save the lists as arrays to the result
+				result.KunyomiReadings = kunyomiReadings.ToArray();
+				result.OnyomiReadings = onyomiReadings.ToArray();
 
-                // Get kanji stroke count (class kanji-details__stroke_count)
-                HtmlNode strokeCountNode = htmlDocument.DocumentNode.SelectSingleNode("//*[@class='kanji-details__stroke_count']");
-                result.Strokes = int.Parse(strokeCountNode.InnerText.Replace("\n", "").Replace("strokes", "").Trim());
+				// Get kanji stroke count (class kanji-details__stroke_count)
+				HtmlNode strokeCountNode =
+					htmlDocument.DocumentNode.SelectSingleNode("//*[@class='kanji-details__stroke_count']");
+				result.Strokes = int.Parse(strokeCountNode.InnerText.Replace("\n", "").Replace("strokes", "").Trim());
 
-                // Get the JLPT level, if exists, from the node with class jlpt
-                HtmlNode jlptNode = htmlDocument.DocumentNode.SelectSingleNode("//div[@class='jlpt']/strong");
-                var jlptText = jlptNode?.InnerText;
-                // if the string fits the form, "N#" where '#' is an integer, 1-9
-                if (jlptText != null && jlptText.Length > 1 && jlptText[0] == 'N' && jlptText[1] > '0' && jlptText[1] <= '9')
-                    result.Jlpt = jlptText[1] - 0x30;
+				// Get the JLPT level, if exists, from the node with class jlpt
+				HtmlNode jlptNode = htmlDocument.DocumentNode.SelectSingleNode("//div[@class='jlpt']/strong");
+				string jlptText = jlptNode?.InnerText;
+				// if the string fits the form, "N#" where '#' is an integer, 1-9
+				if (jlptText != null && jlptText.Length > 1 && jlptText[0] == 'N' && jlptText[1] > '0' && jlptText[1] <= '9')
+					result.Jlpt = jlptText[1] - 0x30;
 
-                return new JishoResult<JishoKanjiDefinition>
-                {
-                    Data = result,
-                    Success = true
-                };
-            }
-            catch (System.Exception e)
-            {
-                return new JishoResult<JishoKanjiDefinition>
-                {
-                    Exception = e.Message,
-                    Success = false
-                };
-            }
-        }
+				return new JishoResult<JishoKanjiDefinition>
+				{
+					Data = result,
+					Success = true
+				};
+			}
+			catch (System.Exception e)
+			{
+				return new JishoResult<JishoKanjiDefinition>
+				{
+					Exception = e.Message,
+					Success = false
+				};
+			}
+		}
 
-        public static JishoResult<JishoKanjiDefinition> GetKanjiDefinition(this JishoClient client, string keyword)
-        {
-            return GetKanjiDefinitionAsync(client, keyword).Result;
-        }
-    }
+		public static JishoResult<JishoKanjiDefinition> GetKanjiDefinition(this JishoClient client, string keyword)
+		{
+			return GetKanjiDefinitionAsync(client, keyword).Result;
+		}
+	}
 }

--- a/JishoNET.Kanji/JishoNET.cs
+++ b/JishoNET.Kanji/JishoNET.cs
@@ -7,78 +7,80 @@ using JishoNET.Models;
 
 namespace JishoNET
 {
-	public static class JishoNETKanji
-	{
-		public static async Task<JishoResult<JishoKanjiDefinition>> GetKanjiDefinitionAsync(this JishoClient client, string keyword)
-		{
-			string kanjiUrlBase = "https://jisho.org/search/";
-			string request = $"{kanjiUrlBase}{keyword} %23kanji";
+    public static class JishoNETKanji
+    {
+        public static async Task<JishoResult<JishoKanjiDefinition>> GetKanjiDefinitionAsync(this JishoClient client, string keyword)
+        {
+            string kanjiUrlBase = "https://jisho.org/search/";
+            string request = $"{kanjiUrlBase}{keyword} %23kanji";
 
-			try
-			{
-				string htmlData = await new HttpClient().GetAsync(request).Result.Content.ReadAsStringAsync();
-				HtmlDocument htmlDocument = new HtmlDocument();
-				htmlDocument.LoadHtml(htmlData);
+            try
+            {
+                string htmlData = await new HttpClient().GetAsync(request).Result.Content.ReadAsStringAsync();
+                HtmlDocument htmlDocument = new HtmlDocument();
+                htmlDocument.LoadHtml(htmlData);
 
-				JishoKanjiDefinition result = new JishoKanjiDefinition();
+                JishoKanjiDefinition result = new JishoKanjiDefinition();
 
-				// Save the user input as the kanji
-				result.Kanji = keyword;
+                // Save the user input as the kanji
+                result.Kanji = keyword;
 
-				// Get the meaning of the kanji from the node with class kanji-details__main-meanings
-				HtmlNode meaningNode = htmlDocument.DocumentNode.SelectSingleNode("//div[@class='kanji-details__main-meanings']");
-				result.Meanings = meaningNode.InnerText.Split(',').Select(x => x.Trim()).ToArray();
+                // Get the meaning of the kanji from the node with class kanji-details__main-meanings
+                HtmlNode meaningNode = htmlDocument.DocumentNode.SelectSingleNode("//div[@class='kanji-details__main-meanings']");
+                result.Meanings = meaningNode.InnerText.Split(',').Select(x => x.Trim()).ToArray();
 
-				// Get the Kunyomi and Onyomi readings from the node with class kanji-details__main-readings
-				HtmlNode readingsNode = htmlDocument.DocumentNode.SelectSingleNode("//div[@class='kanji-details__main-readings']");
+                // Get the Kunyomi and Onyomi readings from the node with class kanji-details__main-readings
+                HtmlNode readingsNode = htmlDocument.DocumentNode.SelectSingleNode("//div[@class='kanji-details__main-readings']");
 
-				// In the readings node there are 2 nodes that need to be processed. 
-				HtmlNode KunyomiNode = readingsNode.SelectSingleNode("//*[@class='dictionary_entry kun_yomi']");
-				HtmlNode OnyomiNode = readingsNode.SelectNodes("//*[@class='dictionary_entry on_yomi']").Last();
+                // In the readings node there are 2 nodes that need to be processed. 
+                HtmlNode KunyomiNode = readingsNode.SelectSingleNode("//*[@class='dictionary_entry kun_yomi']");
+                HtmlNode OnyomiNode = readingsNode.SelectNodes("//*[@class='dictionary_entry on_yomi']").Last();
 
-				List<string> kunyomiReadings = new List<string>();
-				List<string> onyomiReadings = new List<string>();
+                List<string> kunyomiReadings = new List<string>();
+                List<string> onyomiReadings = new List<string>();
 
-				// For each node, extract all the anchor tags and save their inner text, trimmed to a list
-				foreach (HtmlNode node in KunyomiNode.Descendants().Where(x => x.Name == "a"))
-					kunyomiReadings.Add(node.InnerText.Trim());
-				foreach (HtmlNode node in OnyomiNode.Descendants().Where(x => x.Name == "a"))
-					onyomiReadings.Add(node.InnerText.Trim());
+                // For each node, extract all the anchor tags and save their inner text, trimmed to a list
+                if (KunyomiNode != null)
+                    foreach (HtmlNode node in KunyomiNode.Descendants().Where(x => x.Name == "a"))
+                        kunyomiReadings.Add(node.InnerText.Trim());
+                if (OnyomiNode != null)
+                    foreach (HtmlNode node in OnyomiNode.Descendants().Where(x => x.Name == "a"))
+                        onyomiReadings.Add(node.InnerText.Trim());
 
-				// Save the lists as arrays to the result
-				result.KunyomiReadings = kunyomiReadings.ToArray();
-				result.OnyomiReadings = onyomiReadings.ToArray();
+                // Save the lists as arrays to the result
+                result.KunyomiReadings = kunyomiReadings.ToArray();
+                result.OnyomiReadings = onyomiReadings.ToArray();
 
-				// Get kanji stroke count (class kanji-details__stroke_count)
-				HtmlNode strokeCountNode = htmlDocument.DocumentNode.SelectSingleNode("//*[@class='kanji-details__stroke_count']");
-				result.Strokes = int.Parse(strokeCountNode.InnerText.Replace("\n", "").Replace("strokes", "").Trim());
+                // Get kanji stroke count (class kanji-details__stroke_count)
+                HtmlNode strokeCountNode = htmlDocument.DocumentNode.SelectSingleNode("//*[@class='kanji-details__stroke_count']");
+                result.Strokes = int.Parse(strokeCountNode.InnerText.Replace("\n", "").Replace("strokes", "").Trim());
 
                 // Get the JLPT level, if exists, from the node with class jlpt
                 HtmlNode jlptNode = htmlDocument.DocumentNode.SelectSingleNode("//div[@class='jlpt']/strong");
-				var jlptText = jlptNode?.InnerText;
-				// if the string fits the form, "N#" where '#' is an integer, 1-9
+                var jlptText = jlptNode?.InnerText;
+                // if the string fits the form, "N#" where '#' is an integer, 1-9
                 if (jlptText != null && jlptText.Length > 1 && jlptText[0] == 'N' && jlptText[1] > '0' && jlptText[1] <= '9')
-					result.Jlpt = jlptText[1] - 0x30;
+                    result.Jlpt = jlptText[1] - 0x30;
 
                 return new JishoResult<JishoKanjiDefinition>
-				{
-					Data = result,
-					Success = true
-				};
-			}
-			catch (System.Exception e)
-			{
-				return new JishoResult<JishoKanjiDefinition>
-				{
-					Exception = e.Message,
-					Success = false
-				};
-			}
-		}
+                {
+                    Data = result,
+                    Success = true
+                };
+            }
+            catch (System.Exception e)
+            {
+                return new JishoResult<JishoKanjiDefinition>
+                {
+                    Exception = e.Message,
+                    Success = false
+                };
+            }
+        }
 
-		public static JishoResult<JishoKanjiDefinition> GetKanjiDefinition(this JishoClient client, string keyword)
-		{
-			return GetKanjiDefinitionAsync(client, keyword).Result;
-		}
-	}
+        public static JishoResult<JishoKanjiDefinition> GetKanjiDefinition(this JishoClient client, string keyword)
+        {
+            return GetKanjiDefinitionAsync(client, keyword).Result;
+        }
+    }
 }

--- a/JishoNET.Tests/Tests.cs
+++ b/JishoNET.Tests/Tests.cs
@@ -75,15 +75,15 @@ namespace JishoNET.Tests
         public async Task GetKanjiDefinitionWithJlptAsync()
         {
             JishoClient client = new JishoClient();
-            JishoResult<JishoKanjiDefinition> result = await client.GetKanjiDefinitionAsync("川");
+            JishoResult<JishoKanjiDefinition> result = await client.GetKanjiDefinitionAsync("個");
 
             Assert.IsTrue(result.Success, "The request was not successful");
             Assert.IsNull(result.Exception, "An exception occurred whilst executing the request");
             Assert.IsNotNull(result.Data, "The result did not contain any data");
             Assert.IsTrue(result.Data.Meanings.Any());
-            Assert.IsTrue(result.Data.OnyomiReadings.Any());
-            Assert.IsTrue(result.Data.KunyomiReadings.Any());
-            Assert.IsNotNull(result.Data.Jlpt);
+            Assert.IsNotNull(result.Data.OnyomiReadings.Any());
+            Assert.IsNotNull(result.Data.KunyomiReadings);
+            Assert.AreEqual(2, result.Data.Jlpt);
         }
 
         [TestMethod("Get Kanji by extension package (SYNC)")]


### PR DESCRIPTION
Added null checking to OnyomiNode and KunyomiNode, which can be null if a kanji does not have one of either. Modified test case to include this case (exception thrown when not there). Sample list of kanji with only one onyomi or kunyomi: 意, 特, 洋, 員, 倍, 第, 族, 章, 億, 題, 返, 期.

Something weird is going on with the formatting. I'm using the default formatting in Visual Studio 2022 with Windows line enders.